### PR TITLE
Add support for time zone offsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SRC          = src/Main.c                                                  \
 	           src/Log.c                                                   \
 	           src/Power.c                                                 \
 	           src/Signature.c                                             \
+	           src/Time.c                                                 \
 	           src/Timer.c                                                 \
 	           src/Tone.c                                                  \
 	           src/uart.c                                                  \

--- a/src/Config.c
+++ b/src/Config.c
@@ -5,6 +5,7 @@
 
 #include "Board/LEDs.h"
 #include "FatFS/ff.h"
+#include "Log.h"
 #include "Main.h"
 #include "Tone.h"
 #include "UBX.h"
@@ -98,6 +99,13 @@ H_Thresh:  0     ; Minimum horizontal speed for tone (cm/s)\r\n\
 Use_SAS:   1     ; Use skydiver's airspeed\r\n\
                  ;   0 = No\r\n\
                  ;   1 = Yes\r\n\
+TZ_Offset: 0     ; Timezone offset of output files in seconds\r\n\
+                 ;   -14400 = UTC-4 (EDT)\r\n\
+                 ;   -18000 = UTC-5 (EST, CDT)\r\n\
+                 ;   -21600 = UTC-6 (CST, MDT)\r\n\
+                 ;   -25200 = UTC-7 (MST, PDT)\r\n\
+                 ;   -28800 = UTC-8 (PST)\r\n\
+\r\n\
 \r\n\
 ; Alarm settings\r\n\
 \r\n\
@@ -145,6 +153,7 @@ static const char Config_Use_SAS[] PROGMEM    = "Use_SAS";
 static const char Config_Window[] PROGMEM     = "Window";
 static const char Config_Alarm_Elev[] PROGMEM = "Alarm_Elev";
 static const char Config_Alarm_Type[] PROGMEM = "Alarm_Type";
+static const char Config_TZ_Offset[] PROGMEM  = "TZ_Offset";
 
 static void Config_WriteString_P(
 	const char *str,
@@ -231,6 +240,7 @@ void Config_Read(void)
 		HANDLE_VALUE(Config_H_Thresh,  UBX_hThreshold,   val, TRUE);
 		HANDLE_VALUE(Config_Use_SAS,   UBX_use_sas,      val, val == 0 || val == 1);
 		HANDLE_VALUE(Config_Window,    UBX_alarm_window, val * 1000, TRUE);
+		HANDLE_VALUE(Config_TZ_Offset, Log_tz_offset,    val, TRUE);
 		
 		#undef HANDLE_VALUE
 		

--- a/src/FlySight.vcxproj
+++ b/src/FlySight.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="Main.c" />
     <ClCompile Include="Power.c" />
     <ClCompile Include="Signature.c" />
+    <ClCompile Include="Time.c" />
     <ClCompile Include="Timer.c" />
     <ClCompile Include="Tone.c" />
     <ClCompile Include="uart.c" />
@@ -44,6 +45,7 @@
     <ClInclude Include="Main.h" />
     <ClInclude Include="Power.h" />
     <ClInclude Include="Signature.h" />
+    <ClInclude Include="Time.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="Tone.h" />
     <ClInclude Include="uart.h" />

--- a/src/Log.c
+++ b/src/Log.c
@@ -9,8 +9,11 @@
 #include "Log.h"
 #include "Main.h"
 #include "Power.h"
+#include "Time.h"
 
 #define FILE_NUMBER_ADDR 0
+
+int16_t Log_tz_offset = 0;
 
 static uint8_t Log_initialized = 0;
 static DWORD   Log_fattime;
@@ -110,6 +113,13 @@ void Log_Init(
 	FRESULT res;
 
 	if (Log_initialized) return ;
+	
+	// Convert UTC YMD-HMS to a single value, offset it, and convert back
+	{
+		uint32_t timestamp = mk_gmtime(year, month, day, hour, min, sec);
+		timestamp += Log_tz_offset;
+		gmtime_r(timestamp, &year, &month, &day, &hour, &min, &sec);
+	}
 
 	Log_fattime = ((DWORD) (year - 1980) << 25) + 
 	              ((DWORD) month         << 21) + 

--- a/src/Log.h
+++ b/src/Log.h
@@ -3,6 +3,7 @@
 
 extern uint8_t Log_enable_raw;
 extern uint8_t Log_enable_csv;
+extern int16_t Log_tz_offset;
 
 void Log_Flush(void);
 void Log_WriteChar(char ch);

--- a/src/Time.c
+++ b/src/Time.c
@@ -1,0 +1,268 @@
+// Time functions extracted from avr-libc
+
+/*
+ * (C)2012 Michael Duane Rice All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions
+ * and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution. Neither the name of the copyright holders
+ * nor the names of contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "Time.h"
+
+/** One hour, expressed in seconds */
+#define ONE_HOUR 3600
+
+/** Angular degree, expressed in arc seconds */
+#define ONE_DEGREE 3600
+
+/** One day, expressed in seconds */
+#define ONE_DAY 86400
+
+
+enum _MONTHS_ {
+    JANUARY,
+    FEBRUARY,
+    MARCH,
+    APRIL,
+    MAY,
+    JUNE,
+    JULY,
+    AUGUST,
+    SEPTEMBER,
+    OCTOBER,
+    NOVEMBER,
+    DECEMBER
+};
+
+unsigned char
+is_leap_year(int year)
+{
+    div_t           d;
+
+    /* year must be divisible by 4 to be a leap year */
+    if (year & 3)
+        return 0;
+
+    /* If theres a remainder after division by 100, year is not divisible by 100 or 400 */
+    d = div(year, 100);
+    if (d.rem)
+        return 1;
+
+    /* If the quotient is divisible by 4, then year is divisible by 400 */
+    if ((d.quot & 3) == 0)
+        return 1;
+
+    return 0;
+}
+
+
+/*
+    'Break down' a y2k time stamp into the elements of struct tm.
+    Unlike mktime(), this function does not 'normalize' the elements of timeptr.
+
+*/
+
+uint32_t
+mk_gmtime(uint16_t year, uint8_t mon, uint8_t mday, uint8_t hour, uint8_t min, uint8_t sec)
+{
+
+    uint32_t        ret;
+    uint32_t        tmp;
+    int             n, m, d, leaps;
+
+    /*
+        Determine elapsed whole days since the epoch to the beginning of this year. Since our epoch is
+        at a conjunction of the leap cycles, we can do this rather quickly.
+        */
+    n = year - 2000;
+    leaps = 0;
+    if (n) {
+        m = n - 1;
+        leaps = m / 4;
+        leaps -= m / 100;
+        leaps++;
+    }
+    tmp = 365UL * n + leaps;
+
+    /*
+                Derive the day of year from month and day of month. We use the pattern of 31 day months
+                followed by 30 day months to our advantage, but we must 'special case' Jan/Feb, and
+                account for a 'phase change' between July and August (153 days after March 1).
+            */
+    d = mday - 1;   /* tm_mday is one based */
+
+    /* handle Jan/Feb as a special case */
+    if (mon < 2) {
+        if (mon)
+            d += 31;
+
+    } else {
+        n = 59 + is_leap_year(year);
+        d += n;
+        n = mon - MARCH;
+
+        /* account for phase change */
+        if (n > (JULY - MARCH))
+            d += 153;
+        n %= 5;
+
+        /*
+         * n is now an index into a group of alternating 31 and 30
+         * day months... 61 day pairs.
+         */
+        m = n / 2;
+        m *= 61;
+        d += m;
+
+        /*
+         * if n is odd, we are in the second half of the
+         * month pair
+         */
+        if (n & 1)
+            d += 31;
+    }
+
+    /* Add day of year to elapsed days, and convert to seconds */
+    tmp += d;
+    tmp *= ONE_DAY;
+    ret = tmp;
+
+    /* compute 'fractional' day */
+    tmp = hour;
+    tmp *= ONE_HOUR;
+    tmp += min * 60UL;
+    tmp += sec;
+
+    ret += tmp;
+
+    return ret;
+}
+
+void
+gmtime_r(const uint32_t timer, uint16_t *year, uint8_t *mon, uint8_t *mday, uint8_t *hour, uint8_t *min, uint8_t *sec)
+{
+    int32_t         fract;
+    ldiv_t          lresult;
+    div_t           result;
+    uint16_t        days, n, leapyear, years;
+
+    /* break down timer into whole and fractional parts of 1 day */
+    days = timer / 86400UL;
+    fract = timer % 86400UL;
+
+    /*
+            Extract hour, minute, and second from the fractional day
+        */
+    lresult = ldiv(fract, 60L);
+    *sec = lresult.rem;
+    result = div(lresult.quot, 60);
+    *min = result.rem;
+    *hour = result.quot;
+
+    /*
+        * Our epoch year has the property of being at the conjunction of all three 'leap cycles',
+        * 4, 100, and 400 years ( though we can ignore the 400 year cycle in this library).
+        *
+        * Using this property, we can easily 'map' the time stamp into the leap cycles, quickly
+        * deriving the year and day of year, along with the fact of whether it is a leap year.
+        */
+
+    /* map into a 100 year cycle */
+    lresult = ldiv((long) days, 36525L);
+    years = 100 * lresult.quot;
+
+    /* map into a 4 year cycle */
+    lresult = ldiv(lresult.rem, 1461L);
+    years += 4 * lresult.quot;
+    days = lresult.rem;
+    if (years > 100)
+        days++;
+
+    /*
+         * 'years' is now at the first year of a 4 year leap cycle, which will always be a leap year,
+         * unless it is 100. 'days' is now an index into that cycle.
+         */
+    leapyear = 1;
+    if (years == 100)
+        leapyear = 0;
+
+    /* compute length, in days, of first year of this cycle */
+    n = 364 + leapyear;
+
+    /*
+     * if the number of days remaining is greater than the length of the
+     * first year, we make one more division.
+     */
+    if (days > n) {
+        days -= leapyear;
+        leapyear = 0;
+        result = div(days, 365);
+        years += result.quot;
+        days = result.rem;
+    }
+    *year = 2000 + years;
+
+    /*
+            Given the year, day of year, and leap year indicator, we can break down the
+            month and day of month. If the day of year is less than 59 (or 60 if a leap year), then
+            we handle the Jan/Feb month pair as an exception.
+        */
+    n = 59 + leapyear;
+    if (days < n) {
+        /* special case: Jan/Feb month pair */
+        result = div(days, 31);
+        *mon = result.quot;
+        *mday = result.rem;
+    } else {
+        /*
+            The remaining 10 months form a regular pattern of 31 day months alternating with 30 day
+            months, with a 'phase change' between July and August (153 days after March 1).
+            We proceed by mapping our position into either March-July or August-December.
+            */
+        days -= n;
+        result = div(days, 153);
+        uint8_t m;
+        m = 2 + result.quot * 5;
+
+        /* map into a 61 day pair of months */
+        result = div(result.rem, 61);
+        m += result.quot * 2;
+
+        /* map into a month */
+        result = div(result.rem, 31);
+        m += result.quot;
+        *mday = result.rem;
+        *mon = m;
+    }
+
+    /*
+            Cleanup and return
+        */
+    (*mday)++; /* tm_mday is 1 based */
+
+}

--- a/src/Time.h
+++ b/src/Time.h
@@ -1,0 +1,9 @@
+#ifndef TIME_H
+#define TIME_H
+
+#include <stdint.h>
+
+uint32_t mk_gmtime(uint16_t year, uint8_t mon, uint8_t mday, uint8_t hour, uint8_t min, uint8_t sec);
+void gmtime_r(const uint32_t timer, uint16_t *year, uint8_t *mon, uint8_t *mday, uint8_t *hour, uint8_t *min, uint8_t *sec);
+
+#endif // TIME_H


### PR DESCRIPTION
FlySight normally names files and sets modification times using UTC. This changeset adds a `TZ_Offset` configuration value, allowing the user to work in local time.

The logged data retains the same format, e.g. `2013-09-04T02:02:39.50Z`, regardless of `TZ_Offset`, but this way a day's worth of skydives will be stored in the same directory and with filesystem timestamps suitable for correlating with video files or other captured data.
