### PR TITLE
VERSION_BCD takes three parameters

### DIFF
--- a/FlySight/Descriptors.c
+++ b/FlySight/Descriptors.c
@@ -47,7 +47,7 @@ const USB_Descriptor_Device_t PROGMEM DeviceDescriptor =
 {
 	.Header                 = {.Size = sizeof(USB_Descriptor_Device_t), .Type = DTYPE_Device},
 
-	.USBSpecification       = VERSION_BCD(01.10),
+	.USBSpecification       = VERSION_BCD(1,1,0),
 	.Class                  = USB_CSCP_NoDeviceClass,
 	.SubClass               = USB_CSCP_NoDeviceSubclass,
 	.Protocol               = USB_CSCP_NoDeviceProtocol,


### PR DESCRIPTION
`VERSION_BCD(01.10)` doesn't compile for me. I assume it's supposed to be `VERSION_BCD(1,1,0)`.
