### PR TITLE
Add a basic Travis CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+---
+language: c
+before_install:
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -qq gcc-avr binutils-avr avr-libc
+cache: apt
+script: make -C FlySight
+
+


### PR DESCRIPTION
This will give a red/green status on whether or not each branch and pull request builds. As such, it depends on #13 and #14 being merged first. From here, we can do other neat things, like uploading the build results (binaries, symbol maps, etc.) from Travis to S3, but step one is to get it building at all.

Before merging, go to [https://travis-ci.org/](https://travis-ci.org/), sign in with GitHub, and enable Travis for the `flysight/flysight` repo. That configures GitHub to notify Travis on each push and each pull request, at which point Travis will pick it up and do the rest.
