### PR TITLE
Add -fdata-sections to itemize RAM usage in linker map

### DIFF
--- a/FlySight/makefile
+++ b/FlySight/makefile
@@ -35,7 +35,7 @@ SRC          = $(TARGET).c                                                 \
 	           $(LUFA_SRC_USB)                                             \
 	           $(LUFA_SRC_USBCLASS) 
 LUFA_PATH    = ../vendor/lufa/LUFA
-CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -IConfig/
+CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -IConfig/ -fdata-sections
 LD_FLAGS     =
 
 # Default target


### PR DESCRIPTION
Flysight is currently eliminating dead code by compiling with `-ffunction-sections` and telling the linker to discard unused sections. This changeset adds `-fdata-sections`, which applies the same logic to statically-allocated variables.

This doesn't change the resulting image at all, so why do it? Well, this way, the linker map identifies individual declarations.

Before:
![screen shot 2014-03-22 at 9 02 37 pm](https://f.cloud.github.com/assets/118362/2492464/4b6d90ae-b22f-11e3-8184-acc7d66d8d5a.png)

After:
![screen shot 2014-03-22 at 9 02 46 pm](https://f.cloud.github.com/assets/118362/2492465/561b3362-b22f-11e3-84fc-c25788bf6435.png)
