### PR TITLE
Ignore UNIXy build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 *.o
 *.o.d
+*.d
 *.lst
+*.lss
 *.map
 *.eep
 *.elf
+*.bin
 *.hex
 *.sym
 *.tmp


### PR DESCRIPTION
The updated LUFA build scripts produce some files that aren't caught by `.gitignore`. With this change, I can `make all` and still have a clean checkout.
