### PR TITLE
Added Windows driver for virtual serial

### DIFF
--- a/drivers/windows/FlySight.inf
+++ b/drivers/windows/FlySight.inf
@@ -1,0 +1,52 @@
+;************************************************************
+; Windows USB CDC ACM Setup File
+; Copyright (c) 2000 Microsoft Corporation
+;************************************************************
+
+[DefaultInstall]
+CopyINF="FlySight.inf"
+
+[Version]
+Signature="$Windows NT$"
+Class=Ports
+ClassGuid={4D36E978-E325-11CE-BFC1-08002BE10318}
+Provider=%MFGNAME%
+DriverVer=3/23/2014
+
+[Manufacturer]
+%MFGNAME%=DeviceList, NTx86, NTamd64, NTia64
+
+[SourceDisksNames]
+
+[SourceDisksFiles]
+
+[DestinationDirs]
+DefaultDestDir=12
+
+[DriverInstall]
+Include=mdmcpq.inf
+CopyFiles=FakeModemCopyFileSection
+AddReg=DriverInstall.AddReg
+
+[DriverInstall.Services]
+Include=mdmcpq.inf
+AddService=usbser, 0x00000002, LowerFilter_Service_Inst
+
+[DriverInstall.AddReg]
+HKR,,EnumPropPages32,,"msports.dll,SerialPortPropPageProvider"
+
+[DeviceList]
+%DESCRIPTION%=DriverInstall, USB\VID_16D0&PID_0569&MI_00
+
+[DeviceList.NTx86]
+%DESCRIPTION%=DriverInstall, USB\VID_16D0&PID_0569&MI_00
+
+[DeviceList.NTamd64]
+%DESCRIPTION%=DriverInstall, USB\VID_16D0&PID_0569&MI_00
+
+[DeviceList.NTia64]
+%DESCRIPTION%=DriverInstall, USB\VID_16D0&PID_0569&MI_00
+
+[Strings]
+MFGNAME="http://flysight.ca"
+DESCRIPTION="FlySight Virtual Serial Port"


### PR DESCRIPTION
Using the virtual serial port on Windows requires that the `FlySight.inf` driver be installed. To install the driver:
1. Plug in the FlySight.
2. Open the Windows Device Manager. The FlySight should appear under "Other Devices" with a warning symbol next to it:

![image](https://f.cloud.github.com/assets/145303/2495636/620c6446-b2fe-11e3-8e29-e33061a75710.png)
1. Right-click on the device and choose "Update Driver Software" from the menu.
2. Choose "Browse my computer for driver software".
3. Locate the folder containing `FlySight.inf`, then click Next.
4. If prompted, choose "Install this driver software anyway":

![image](https://f.cloud.github.com/assets/145303/2495643/bd5e2802-b2fe-11e3-9af9-e035481e605d.png)
1. The FlySight should now appear under "Ports":

![image](https://f.cloud.github.com/assets/145303/2495646/d9a8867e-b2fe-11e3-82d6-3228ed4801ce.png)
