### PR TITLE
Change to root folder before opening log file

### DIFF
--- a/src/Log.c
+++ b/src/Log.c
@@ -122,6 +122,7 @@ void Log_Init(
     year = year % 100;
     Log_ToDate(fname, year, month, day);
 
+	res = f_chdir("\\");
 	res = f_mkdir(fname);
 	res = f_chdir(fname);
 


### PR DESCRIPTION
Previously, we weren't changing to the root folder before creating the log folder and opening the new file. This meant that if an audio files was opened first, the log would be created in the `audio` folder. We now change to the root folder first so that the log folder is created in the right place.
