### PR TITLE
Changed USB CDC interface to compile-time option

### DIFF
--- a/src/Descriptors.c
+++ b/src/Descriptors.c
@@ -77,7 +77,11 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			.Header                 = {.Size = sizeof(USB_Descriptor_Configuration_Header_t), .Type = DTYPE_Configuration},
 
 			.TotalConfigurationSize = sizeof(USB_Descriptor_Configuration_t),
+#ifdef USE_SERIAL_INTERFACE
 			.TotalInterfaces        = 3,
+#else
+			.TotalInterfaces        = 1,
+#endif
 
 			.ConfigurationNumber    = 1,
 			.ConfigurationStrIndex  = NO_DESCRIPTOR,
@@ -87,6 +91,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			.MaxPowerConsumption    = USB_CONFIG_POWER_MA(250)
 		},
 
+#ifdef USE_SERIAL_INTERFACE
 	.CDC_IAD =
 		{
 			.Header                 = {.Size = sizeof(USB_Descriptor_Interface_Association_t), .Type = DTYPE_InterfaceAssociation},
@@ -187,6 +192,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			.EndpointSize           = CDC_TXRX_EPSIZE,
 			.PollingIntervalMS      = 0x05
 		},
+#endif		
 
 	.MS_Interface =
 		{

--- a/src/Descriptors.h
+++ b/src/Descriptors.h
@@ -43,7 +43,11 @@
 
 		#include "Config/AppConfig.h"
 
+	/* Enable/disable serial interface: */
+		// #define USE_SERIAL_INTERFACE
+		
 	/* Macros: */
+#ifdef USE_SERIAL_INTERFACE
 		/** Endpoint address of the CDC device-to-host notification IN endpoint. */
 		#define CDC_NOTIFICATION_EPADDR        (ENDPOINT_DIR_IN  | 1)
 
@@ -64,6 +68,13 @@
 
 		/** Endpoint address of the Mass Storage host-to-device data OUT endpoint. */
 		#define MASS_STORAGE_OUT_EPADDR        (ENDPOINT_DIR_OUT | 5)
+#else
+		/** Endpoint address of the Mass Storage device-to-host data IN endpoint. */
+		#define MASS_STORAGE_IN_EPADDR         (ENDPOINT_DIR_IN  | 3)
+
+		/** Endpoint address of the Mass Storage host-to-device data OUT endpoint. */
+		#define MASS_STORAGE_OUT_EPADDR        (ENDPOINT_DIR_OUT | 4)
+#endif
 
 		/** Size in bytes of the Mass Storage data endpoints. */
 		#define MASS_STORAGE_IO_EPSIZE         64
@@ -76,6 +87,7 @@
 		{
 			USB_Descriptor_Configuration_Header_t    Config;
 
+#ifdef USE_SERIAL_INTERFACE
 			// CDC Control Interface
 			USB_Descriptor_Interface_Association_t   CDC_IAD;
 			USB_Descriptor_Interface_t               CDC_CCI_Interface;
@@ -88,6 +100,7 @@
 			USB_Descriptor_Interface_t               CDC_DCI_Interface;
 			USB_Descriptor_Endpoint_t                CDC_DataOutEndpoint;
 			USB_Descriptor_Endpoint_t                CDC_DataInEndpoint;
+#endif
 
 			// Mass Storage Interface
 			USB_Descriptor_Interface_t               MS_Interface;
@@ -101,9 +114,13 @@
 	 */
 		enum InterfaceDescriptors_t
 		{
+#ifdef USE_SERIAL_INTERFACE
 			INTERFACE_ID_CDC_CCI     = 0, /**< CDC CCI interface descriptor ID */
 			INTERFACE_ID_CDC_DCI     = 1, /**< CDC DCI interface descriptor ID */
 			INTERFACE_ID_MassStorage = 2, /**< Mass storage interface descriptor ID */
+#else
+			INTERFACE_ID_MassStorage = 0, /**< Mass storage interface descriptor ID */
+#endif
 		};
 
 		/** Enum for the device string descriptor IDs within the device. Each string descriptor should

--- a/src/UsbInterface.c
+++ b/src/UsbInterface.c
@@ -23,6 +23,7 @@ USB_ClassInfo_MS_Device_t Disk_MS_Interface =
 	},
 };
 
+#ifdef USE_SERIAL_INTERFACE
 USB_ClassInfo_CDC_Device_t UBX_CDC_Interface =
 {
 	.Config =
@@ -48,6 +49,7 @@ USB_ClassInfo_CDC_Device_t UBX_CDC_Interface =
 				},
 		},
 };
+#endif
 
 
 void EVENT_USB_Device_Connect(void)
@@ -63,13 +65,17 @@ void EVENT_USB_Device_Disconnect(void)
 void EVENT_USB_Device_ConfigurationChanged(void)
 {
 	MS_Device_ConfigureEndpoints(&Disk_MS_Interface) ;
+#ifdef USE_SERIAL_INTERFACE
 	CDC_Device_ConfigureEndpoints(&UBX_CDC_Interface);
+#endif
 }
 
 void EVENT_USB_Device_ControlRequest(void)
 {
 	MS_Device_ProcessControlRequest(&Disk_MS_Interface);
+#ifdef USE_SERIAL_INTERFACE
 	CDC_Device_ProcessControlRequest(&UBX_CDC_Interface);
+#endif
 }
 
 bool CALLBACK_MS_Device_SCSICommandReceived(
@@ -86,6 +92,7 @@ bool CALLBACK_MS_Device_SCSICommandReceived(
 
 void USBInterfaceTask(void)
 {
+#ifdef USE_SERIAL_INTERFACE
 	uint16_t ch;
 	
 	// Pipe UART in -> CDC out
@@ -100,5 +107,6 @@ void USBInterfaceTask(void)
 	
 	// Pump LUFA for both interfaces
 	CDC_Device_USBTask(&UBX_CDC_Interface);
+#endif
 	MS_Device_USBTask(&Disk_MS_Interface);
 }


### PR DESCRIPTION
Added `#define USE_SERIAL_INTERFACE` in `Descriptors.h` to control whether the FlySight will act as a composite CDC/mass storage device or simply as a mass storage device.
