### PR TITLE
Changed atoi to strol in Config.c

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -205,7 +205,7 @@ void Config_Read(void)
 		result = strtok(0, " \t:");
 		if (result == 0) continue ;
 		
-		val = strtol(result, NULL, 10);
+		val = atol(result);
 		
 		#define HANDLE_VALUE(s,w,r,t) \
 			if ((t) && !strcmp_P(name, (s))) { (w) = (r); }


### PR DESCRIPTION
Use of atoi in Config.c was truncating values to int16. Changing to strtol allows us to read full 32-bit configuration values.
