### PR TITLE
Adjust chirp step to account for tone sample length

### DIFF
--- a/src/Tone.c
+++ b/src/Tone.c
@@ -378,7 +378,7 @@ void Tone_Beep(
 	Tone_Stop();
 	
 	Tone_step  = ((int32_t) index * 3242 + 30212096) * TONE_SAMPLE_LEN;
-	Tone_chirp = chirp;
+	Tone_chirp = chirp * TONE_SAMPLE_LEN * TONE_SAMPLE_LEN;
 	Tone_len   = len / TONE_SAMPLE_LEN;
 	
 	Tone_Start(TONE_MODE_BEEP);


### PR DESCRIPTION
A chirp should cover the full tone scale in the length of a single beep. Two factors affect the chirp step per sample:
- The phase step for a particular frequency is scaled by the sample length multiplier.
- The length, in samples, of the beep is also scaled by the sample length multiplier.

Because of these two effects, `Tone_chirp` must be multiplied twice by `TONE_SAMPLE_LEN` to account for changes in the sample length.
