### PR TITLE
Add ground elevation parameter

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -121,9 +121,9 @@ TZ_Offset: 0     ; Timezone offset of output files in seconds\r\n\
 ;          level.\r\n\
 \r\n\
 Window:        0 ; Alarm window (m)\r\n\
-DZ_Elev:       0 ; Ground elevation (m)\r\n\
+DZ_Elev:       0 ; Ground elevation (m above sea level)\r\n\
 \r\n\
-Alarm_Elev: 1000 ; Alarm elevation (m)\r\n\
+Alarm_Elev: 1000 ; Alarm elevation (m above ground level)\r\n\
 Alarm_Type:    0 ; Alarm type\r\n\
                  ;   0 = No alarm\r\n\
                  ;   1 = Beep\r\n\


### PR DESCRIPTION
I've added the `DZ_Elev` configuration parameter in order to simplify alarm setting. I found myself constantly doing the math to convert AGL alarm elevations to MSL elevations for the configuration file. The new parameter will allow users to enter the DZ elevation once and enter alarm elevations separately as an AGL value.
