### PR TITLE
Changed default speech volume to 8

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -88,7 +88,7 @@ Sp_Units:  1     ; Speech units\r\n\
 Sp_Rate:   0     ; Speech rate (s)\r\n\
                  ;   0 = No speech\r\n\
 Sp_Dec:    0     ; Decimal places for speech\r\n\
-Sp_Volume: 6     ; 0 (min) to 8 (max)\r\n\
+Sp_Volume: 8     ; 0 (min) to 8 (max)\r\n\
 \r\n\
 ; Thresholds\r\n\
 \r\n\

--- a/src/Tone.c
+++ b/src/Tone.c
@@ -78,7 +78,7 @@ static          uint8_t  Tone_mode;
 static          FIL      Tone_file;
 
                 uint16_t Tone_volume = 2;
-                uint16_t Tone_sp_volume = 2;
+                uint16_t Tone_sp_volume = 0;
 
 static volatile uint16_t Tone_next_index = 0;
 static volatile uint32_t Tone_next_chirp = 0; 


### PR DESCRIPTION
Speech is naturally a bit quieter than tones, so I've increased the default speech volume to 8.
