### PR TITLE
Fix UBX message handling

### DIFF
--- a/src/UBX.c
+++ b/src/UBX.c
@@ -859,8 +859,7 @@ static void UBX_UpdateTones(
 		{
 			UBX_SetTone(val_1, min_1, max_1, val_2, min_2, max_2);
 				
-			if (UBX_sp_rate != 0 && 
-				UBX_sp_counter >= UBX_sp_rate)
+			if (UBX_sp_rate != 0 && UBX_sp_counter >= UBX_sp_rate)
 			{
 				UBX_SpeakValue(current);
 				UBX_sp_counter = 0;


### PR DESCRIPTION
Previously, UBX messages were handled as they were received from the u-blox GPS module. However, this resulted in some anomalies with audio, particularly around alarms and at startup. This update handles all of the messages at once when a complete set has been received.
