### PR TITLE
Remove alarm warble option

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -129,8 +129,7 @@ Alarm_Type:    0 ; Alarm type\r\n\
                  ;   0 = No alarm\r\n\
                  ;   1 = Beep\r\n\
                  ;   2 = Chirp up\r\n\
-                 ;   3 = Chirp down\r\n\
-                 ;   4 = Warble\r\n";
+                 ;   3 = Chirp down\r\n";
 
 static const char Config_Model[] PROGMEM      = "Model";
 static const char Config_Rate[] PROGMEM       = "Rate";

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -806,9 +806,6 @@ static void UBX_UpdateAlarms(
 				case 3:	// chirp down
 					Tone_Beep(TONE_MAX_PITCH - 1, -TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
 					break ;
-				case 4:	// warble
-					Tone_Beep(0, 5 * TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
-					break ;
 				}
 				
 				break;


### PR DESCRIPTION
Warble option requires the tone step to wrap. Rather than add overhead to tone generation, I've chosen to remove this option for the time being.