### PR TITLE
Use default configuration file

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -307,14 +307,5 @@ void Config_Read(void)
 
 		Config_WriteString_P(Config_default, &Main_file);
 		f_close(&Main_file);
-
-		res = f_chdir("\\config");
-		res = f_open(&Main_file, "config.txt", FA_READ);
-		if (res != FR_OK)
-		{
-			Main_activeLED = LEDS_RED;
-			LEDs_ChangeLEDs(LEDS_ALL_LEDS, Main_activeLED);
-			return ;
-		}
 	}
 }


### PR DESCRIPTION
This pull request changes the configuration read so that the root "config.txt" is read first and then the file in the "config" folder overrides any values it specified. This allows the user to set up a lot of default values in the root configuration file and only differences from those defaults in the "config" folder.