### PR TITLE
Added silence windows

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -143,7 +143,17 @@ Alarm_Type:    0 ; Alarm type\r\n\
                  ;   2 = Chirp up\r\n\
                  ;   3 = Chirp down\r\n\
                  ;   4 = Play file\r\n\
-Alarm_File:    0 ; File to be played\r\n";
+Alarm_File:    0 ; File to be played\r\n\
+\r\n\
+; Alarm windows\r\n\
+\r\n\
+; NOTE:    Alarm windows are given in meters above ground\r\n\
+;          elevation, which is specified in DZ_Elev. Tones\r\n\
+;          will be silenced during these windows and only\r\n\
+;          alarms will be audible.\r\n\
+\r\n\
+Win_Top:       0 ; Alarm window top (m)\r\n\
+Win_Bottom:    0 ; Alarm window bottom (m)\r\n";
 
 static const char Config_Model[] PROGMEM      = "Model";
 static const char Config_Rate[] PROGMEM       = "Rate";
@@ -174,6 +184,8 @@ static const char Config_Alarm_File[] PROGMEM = "Alarm_File";
 static const char Config_TZ_Offset[] PROGMEM  = "TZ_Offset";
 static const char Config_Init_Mode[] PROGMEM  = "Init_Mode";
        const char Config_Init_File[] PROGMEM  = "Init_File";
+static const char Config_Win_Top[] PROGMEM    = "Win_Top";
+static const char Config_Win_Bottom[] PROGMEM = "Win_Bottom";
 
 char Config_buf[80];
 
@@ -307,6 +319,16 @@ void Config_Read(void)
 		if (!strcmp_P(name, Config_Alarm_File))
 		{
 			strcpy(UBX_alarms[UBX_num_alarms - 1].filename, result);
+		}
+		
+		if (!strcmp_P(name, Config_Win_Top))
+		{
+			++UBX_num_windows;
+			UBX_windows[UBX_num_windows - 1].top = val * 1000 + dz_elev;
+		}
+		if (!strcmp_P(name, Config_Win_Bottom))
+		{
+			UBX_windows[UBX_num_windows - 1].bottom = val * 1000 + dz_elev;
 		}
 	}
 	

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -264,6 +264,9 @@ static uint8_t  UBX_msg_received = 0;
 
 char UBX_buf[150];
 
+UBX_window UBX_windows[UBX_MAX_WINDOWS];
+uint8_t    UBX_num_windows = 0;
+
 typedef struct
 {
 	int32_t  lon;      // Longitude                    (deg)
@@ -796,7 +799,16 @@ static void UBX_UpdateAlarms(
 
 	for (i = 0; i < UBX_num_alarms; ++i)
 	{
-		if (ABS (UBX_alarms[i].elev - current->hMSL) < UBX_alarm_window)
+		if (ABS (UBX_alarms[i].elev - current->hMSL) <= UBX_alarm_window)
+		{
+			suppress_tone = 1;
+			break;
+		}
+	}
+	
+	for (i = 0; i < UBX_num_windows; ++i)
+	{
+		if ((UBX_windows[i].bottom <= current->hMSL) && (UBX_windows[i].top >= current->hMSL))
 		{
 			suppress_tone = 1;
 			break;

--- a/src/UBX.h
+++ b/src/UBX.h
@@ -3,7 +3,8 @@
 
 #include <avr/io.h>
 
-#define UBX_MAX_ALARMS 10
+#define UBX_MAX_ALARMS  10
+#define UBX_MAX_WINDOWS 2
 
 typedef struct
 {
@@ -12,6 +13,13 @@ typedef struct
 	char    filename[9];
 }
 UBX_alarm;
+
+typedef struct
+{
+	int32_t top;
+	int32_t bottom;
+}
+UBX_window;
 
 extern uint8_t   UBX_model;
 extern uint16_t  UBX_rate;
@@ -44,6 +52,9 @@ extern uint8_t   UBX_init_mode;
 extern char      UBX_init_filename[9];
 
 extern char      UBX_buf[150];
+
+extern UBX_window UBX_windows[UBX_MAX_WINDOWS];
+extern uint8_t    UBX_num_windows;
 
 void UBX_Init(void);
 void UBX_Task(void);


### PR DESCRIPTION
Added "silence windows" which function similarly to the window around each alarm but are specified by a top and bottom elevation. This makes it easier, e.g., to use tones/speech only inside the competition window. Currently there is are a maximum of two silence windows allowed.