### PR TITLE
Block while playing init file

### DIFF
--- a/src/Main.c
+++ b/src/Main.c
@@ -101,10 +101,7 @@ static void ReadSingleConfigName(
 			Tone_Hold();
 			
 			Tone_Play(UBX_buf);
-			while (!Tone_IsIdle())
-			{
-				Tone_Task();
-			}
+			Tone_Wait();
 			
 			Tone_Release();
 			Power_Release();
@@ -138,6 +135,44 @@ static void ReadConfigNames(void)
 	}
 
 	eeprom_write_block("", CONFIG_FNAME_ADDR, CONFIG_FNAME_LEN);
+}
+
+static void ReadInitFile(void)
+{
+	uint8_t i;
+
+	Power_Hold();
+	Tone_Hold();
+	
+	if (UBX_init_mode == 1)			// Speech test
+	{
+		for (i = 0; i < 10; ++i)
+		{
+			UBX_buf[0] = i + '0';
+			UBX_buf[1] = 0;
+			strcat(UBX_buf, ".wav");
+
+			Tone_Play(UBX_buf);
+			Tone_Wait();
+		}
+
+		Tone_Play("dot.wav");
+		Tone_Wait();
+
+		Tone_Play("minus.wav");
+		Tone_Wait();
+	}
+	else if (UBX_init_mode == 2)	// Play a file
+	{
+		strcpy(UBX_buf, UBX_init_filename);
+		strcat(UBX_buf, ".wav");
+
+		Tone_Play(UBX_buf);
+		Tone_Wait();
+	}
+	
+	Tone_Release();
+	Power_Release();
 }
 
 int main(void)
@@ -215,6 +250,8 @@ int main(void)
 		Signature_Write();
 		Config_Read();
 		Power_Release();
+				
+		ReadInitFile();
 		
 		Timer_Init();
 		UBX_Init();

--- a/src/Tone.c
+++ b/src/Tone.c
@@ -391,6 +391,14 @@ void Tone_Play(
 	}
 }
 
+void Tone_Wait(void)
+{
+	while (Tone_state != TONE_STATE_IDLE)
+	{
+		Tone_Task();
+	}
+}
+
 uint8_t Tone_CanWrite(void)
 {
 	uint16_t c;

--- a/src/Tone.h
+++ b/src/Tone.h
@@ -25,6 +25,7 @@ void Tone_Task(void);
 
 void Tone_Beep(uint16_t index, uint32_t chirp, uint16_t len);
 void Tone_Play(const char *filename);
+void Tone_Wait(void);
 void Tone_Stop(void);
 
 uint8_t Tone_CanWrite(void);

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -1155,32 +1155,7 @@ void UBX_Init(void)
 		LEDs_ChangeLEDs(LEDS_ALL_LEDS, LEDS_RED);
 		while (1);
 	}
-
-	if (UBX_init_mode == 1)			// Speech test
-	{
-		UBX_speech_buf[0] = '0';
-		UBX_speech_buf[1] = '1';
-		UBX_speech_buf[2] = '2';
-		UBX_speech_buf[3] = '3';
-		UBX_speech_buf[4] = '4';
-		UBX_speech_buf[5] = '5';
-		UBX_speech_buf[6] = '6';
-		UBX_speech_buf[7] = '7';
-		UBX_speech_buf[8] = '8';
-		UBX_speech_buf[9] = '9';
-		UBX_speech_buf[10] = '.';
-		UBX_speech_buf[11] = '-';
-		UBX_speech_buf[12] = 0;
-		UBX_speech_ptr = UBX_speech_buf;
-	}
-	else if (UBX_init_mode == 2)	// Play a file
-	{
-		strcpy(UBX_buf, UBX_init_filename);
-		strcat(UBX_buf, ".wav");
-		Tone_Play(UBX_buf);
-	}
 }
-
 
 void UBX_Task(void)
 {


### PR DESCRIPTION
This fixes an issue where the init file would start playing but then the unit would get a fix, causing a log file to be opened. The file opening process is slow enough that the play buffer would overrun and the init file would be aborted.

To fix this, the init file is now played in ```Main.c``` just after the configuration file is read. Playback blocks other tasks until it is complete.