### PR TITLE
Split alarm window into upper and lower

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -134,7 +134,8 @@ Init_File: 0     ; File to be played\r\n\
 ; NOTE:    Alarm elevations are given in meters above ground\r\n\
 ;          elevation, which is specified in DZ_Elev.\r\n\
 \r\n\
-Window:        0 ; Alarm window (m)\r\n\
+Win_Above:     0 ; Window above each alarm (m)\r\n\
+Win_Below:     0 ; Window below each alarm (m)\r\n\
 DZ_Elev:       0 ; Ground elevation (m above sea level)\r\n\
 \r\n\
 Alarm_Elev:    0 ; Alarm elevation (m above ground level)\r\n\
@@ -178,6 +179,8 @@ static const char Config_V_Thresh[] PROGMEM   = "V_Thresh";
 static const char Config_H_Thresh[] PROGMEM   = "H_Thresh";
 static const char Config_Use_SAS[] PROGMEM    = "Use_SAS";
 static const char Config_Window[] PROGMEM     = "Window";
+static const char Config_Window_Above[] PROGMEM = "Win_Above";
+static const char Config_Window_Below[] PROGMEM = "Win_Below";
 static const char Config_DZ_Elev[] PROGMEM    = "DZ_Elev";
 static const char Config_Alarm_Elev[] PROGMEM = "Alarm_Elev";
 static const char Config_Alarm_Type[] PROGMEM = "Alarm_Type";
@@ -258,7 +261,10 @@ static FRESULT Config_ReadSingle(
 		HANDLE_VALUE(Config_V_Thresh,  UBX_threshold,    val, TRUE);
 		HANDLE_VALUE(Config_H_Thresh,  UBX_hThreshold,   val, TRUE);
 		HANDLE_VALUE(Config_Use_SAS,   UBX_use_sas,      val, val == 0 || val == 1);
-		HANDLE_VALUE(Config_Window,    UBX_alarm_window, val * 1000, TRUE);
+		HANDLE_VALUE(Config_Window,    UBX_alarm_window_above, val * 1000, TRUE);
+		HANDLE_VALUE(Config_Window,    UBX_alarm_window_below, val * 1000, TRUE);
+		HANDLE_VALUE(Config_Window_Above, UBX_alarm_window_above, val * 1000, TRUE);
+		HANDLE_VALUE(Config_Window_Below, UBX_alarm_window_below, val * 1000, TRUE);
 		HANDLE_VALUE(Config_DZ_Elev,   UBX_dz_elev,      val * 1000, TRUE);
 		HANDLE_VALUE(Config_TZ_Offset, Log_tz_offset,    val, TRUE);
 		HANDLE_VALUE(Config_Init_Mode, UBX_init_mode,    val, val >= 0 && val <= 2);

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -257,7 +257,8 @@ uint32_t UBX_hThreshold    = 0;
 
 UBX_alarm UBX_alarms[UBX_MAX_ALARMS];
 uint8_t   UBX_num_alarms   = 0;
-uint32_t  UBX_alarm_window = 0;
+uint32_t  UBX_alarm_window_above = 0;
+uint32_t  UBX_alarm_window_below = 0;
 
 static uint32_t UBX_time_of_week = 0;
 static uint8_t  UBX_msg_received = 0;
@@ -801,7 +802,8 @@ static void UBX_UpdateAlarms(
 
 	for (i = 0; i < UBX_num_alarms; ++i)
 	{
-		if (ABS (UBX_alarms[i].elev - current->hMSL) <= UBX_alarm_window)
+		if (current->hMSL - UBX_alarms[i].elev <= UBX_alarm_window_above &&
+		    UBX_alarms[i].elev - current->hMSL <= UBX_alarm_window_below)
 		{
 			suppress_tone = 1;
 			break;

--- a/src/UBX.h
+++ b/src/UBX.h
@@ -41,7 +41,8 @@ extern uint32_t  UBX_hThreshold;
 
 extern UBX_alarm UBX_alarms[UBX_MAX_ALARMS];
 extern uint8_t   UBX_num_alarms;
-extern uint32_t  UBX_alarm_window;
+extern uint32_t  UBX_alarm_window_above;
+extern uint32_t  UBX_alarm_window_below;
 
 extern uint8_t   UBX_sp_mode;
 extern uint8_t   UBX_sp_units;


### PR DESCRIPTION
This change allows users to specify separate alarm windows above and below the alarm, so that tones can begin immediately after the alarm has sounded. The old "Alarm_Window" setting is still handled and sets both the upper and lower window.