### PR TITLE
Add swapped chirp in Limits

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -54,6 +54,7 @@ Limits:    1     ; Behaviour when outside bounds\r\n\
                  ;   0 = No tone\r\n\
                  ;   1 = Min/max tone\r\n\
                  ;   2 = Chirp up/down\r\n\
+                 ;   3 = Chirp down/up\r\n\
 Volume:    6     ; 0 (min) to 8 (max)\r\n\
 \r\n\
 ; Rate settings\r\n\

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -598,10 +598,15 @@ static void UBX_SetTone(
 				Tone_SetPitch(0);
 				Tone_SetChirp(0);
 			}
-			else
+			else if (UBX_limits == 2)
 			{
 				Tone_SetPitch(0);
 				Tone_SetChirp(TONE_CHIRP_MAX);
+			}
+			else
+			{
+				Tone_SetPitch(TONE_MAX_PITCH - 1);
+				Tone_SetChirp(-TONE_CHIRP_MAX);
 			}
 		}
 		else if (OVER(val_1, min_1, max_1))
@@ -615,10 +620,15 @@ static void UBX_SetTone(
 				Tone_SetPitch(TONE_MAX_PITCH - 1);
 				Tone_SetChirp(0);
 			}
-			else
+			else if (UBX_limits == 2)
 			{
 				Tone_SetPitch(TONE_MAX_PITCH - 1);
 				Tone_SetChirp(-TONE_CHIRP_MAX);
+			}
+			else
+			{
+				Tone_SetPitch(0);
+				Tone_SetChirp(TONE_CHIRP_MAX);
 			}
 		}
 		else


### PR DESCRIPTION
Added a new option for the Limits parameter which produces chirps above/below the tone range but uses the opposite chirps (i.e., chirps down instead of up and vice versa).