### PR TITLE
Stop playback only if there is nothing left to load

### DIFF
--- a/src/Tone.c
+++ b/src/Tone.c
@@ -100,11 +100,21 @@ ISR(TIMER1_OVF_vect)
 	}
 	else if (Tone_read == Tone_write)
 	{
-		TCCR1A = 0;
-		TCCR1B = 0;
-		TIMSK1 = 0;
+		if (Tone_flags & TONE_FLAGS_LOAD)
+		{
+			// Buffer underflow
+			s1 = s2;
+			step = 0;
+		}
+		else
+		{
+			// We are done playing
+			TCCR1A = 0;
+			TCCR1B = 0;
+			TIMSK1 = 0;
 
-		Tone_flags |= TONE_FLAGS_STOP;
+			Tone_flags |= TONE_FLAGS_STOP;
+		}
 	}
 	else 
 	{


### PR DESCRIPTION
This changes fixes the issue that audio will be cut off if an underflow condition occurs--i.e., if there is no audio left in the buffer but we have not finished playing the sound. Instead, we will now continue to play the previous sample until new audio is available. This should prevent, e.g., alarms or initialization sounds from being cut off.