### PR TITLE
Fix gps init

### DIFF
--- a/src/Main.c
+++ b/src/Main.c
@@ -196,6 +196,9 @@ int main(void)
 	delay_ms(500);
 	eeprom_write_byte(BOOTLOADER_COUNT_ADDR, 0);
 
+	// Turn LED red during initialization
+	LEDs_ChangeLEDs(LEDS_ALL_LEDS, LEDS_RED);
+
 	if (USB_VBUS_GetStatus())
 	{
 		if (!Main_mmcInitialized)
@@ -231,16 +234,6 @@ int main(void)
 	{
 		USB_Disable();
 
-		if (Main_mmcInitialized)
-		{
-			Main_activeLED = LEDS_GREEN;
-		}
-		else
-		{
-			Main_activeLED = LEDS_RED;
-		}
-		LEDs_ChangeLEDs(LEDS_ALL_LEDS, Main_activeLED);
-
 		if (count == 1)
 		{
 			ReadConfigNames();
@@ -255,6 +248,16 @@ int main(void)
 		
 		Timer_Init();
 		UBX_Init();
+
+		if (Main_mmcInitialized)
+		{
+			Main_activeLED = LEDS_GREEN;
+		}
+		else
+		{
+			Main_activeLED = LEDS_RED;
+		}
+		LEDs_ChangeLEDs(LEDS_ALL_LEDS, Main_activeLED);
 
 		for (;;)
 		{

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -1117,27 +1117,29 @@ void UBX_Init(void)
 		.reserved5    = 0       // Reserved, set to 0
 	};
 
-	uint8_t success = 1;
-	
-	uart_init(51); // 9600 baud
-	
-	UBX_SendMessage(UBX_CFG, UBX_CFG_PRT, sizeof(cfg_prt), &cfg_prt);
+	do
+	{
+		uart_init(51); // 9600 baud
 
-	// NOTE: We don't wait for ACK here since some FlySights will already be
-	//       set to 38400 baud.
-	
-	while (!uart_tx_empty());
+		UBX_SendMessage(UBX_CFG, UBX_CFG_PRT, sizeof(cfg_prt), &cfg_prt);
 
-	uart_init(12); // 38400 baud
+		// NOTE: We don't wait for ACK here since some FlySights will already be
+		//       set to 38400 baud.
 
-	_delay_ms(10); // wait for GPS UART to reset
-	
-	UBX_SendMessage(UBX_CFG, UBX_CFG_PRT, sizeof(cfg_prt), &cfg_prt);
-	if (!UBX_WaitForAck(UBX_CFG, UBX_CFG_PRT, UBX_TIMEOUT)) success = 0;
+		while (!uart_tx_empty());
 
-	#define SEND_MESSAGE(c,m,d) { \
-		UBX_SendMessage(c,m,sizeof(d),&d); \
-		if (!UBX_WaitForAck(c,m,UBX_TIMEOUT)) success = 0; }
+		uart_init(12); // 38400 baud
+
+		_delay_ms(10); // wait for GPS UART to reset
+
+		UBX_SendMessage(UBX_CFG, UBX_CFG_PRT, sizeof(cfg_prt), &cfg_prt);
+	}
+	while (!UBX_WaitForAck(UBX_CFG, UBX_CFG_PRT, UBX_TIMEOUT));
+
+	#define SEND_MESSAGE(c,m,d) \
+		do { \
+			UBX_SendMessage(c,m,sizeof(d),&d); \
+		} while (!UBX_WaitForAck(c,m,UBX_TIMEOUT));
 
 	for (i = 0; i < n; ++i)
 	{
@@ -1149,12 +1151,6 @@ void UBX_Init(void)
 	SEND_MESSAGE(UBX_CFG, UBX_CFG_RST,  cfg_rst);
 	
 	#undef SEND_MESSAGE
-
-	if (!success)
-	{
-		LEDs_ChangeLEDs(LEDS_ALL_LEDS, LEDS_RED);
-		while (1);
-	}
 }
 
 void UBX_Task(void)


### PR DESCRIPTION
This change prevents initialization from completing unless the GPS is properly initialized. The firmware will repeat initialization commands until they are acknowledged by the u-blox module. The red light will turn on when initialization starts and won't turn off until it's complete, so a solid red light indicates that the unit is hung up during initialization. Initialization will proceed if the microSD card has not been initialized, but in this case the red LED will remain on and will flash when a fix is achieved.