### PR TITLE
Fix issues with DZ_Elev

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -335,7 +335,7 @@ static FRESULT Config_ReadSingle(
 		if (!strcmp_P(name, Config_Alarm_Elev) && UBX_num_alarms < UBX_MAX_ALARMS)
 		{
 			++UBX_num_alarms;
-			UBX_alarms[UBX_num_alarms - 1].elev = val * 1000 + UBX_dz_elev;
+			UBX_alarms[UBX_num_alarms - 1].elev = val * 1000;
 			UBX_alarms[UBX_num_alarms - 1].type = 0;
 			UBX_alarms[UBX_num_alarms - 1].filename[0] = '\0';
 		}
@@ -352,11 +352,11 @@ static FRESULT Config_ReadSingle(
 		if (!strcmp_P(name, Config_Win_Top) && UBX_num_windows < UBX_MAX_WINDOWS)
 		{
 			++UBX_num_windows;
-			UBX_windows[UBX_num_windows - 1].top = val * 1000 + UBX_dz_elev;
+			UBX_windows[UBX_num_windows - 1].top = val * 1000;
 		}
 		if (!strcmp_P(name, Config_Win_Bottom) && UBX_num_windows <= UBX_MAX_WINDOWS)
 		{
-			UBX_windows[UBX_num_windows - 1].bottom = val * 1000 + UBX_dz_elev;
+			UBX_windows[UBX_num_windows - 1].bottom = val * 1000;
 		}
 	}
 	

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -912,8 +912,10 @@ static void UBX_UpdateAlarms(
 
 	for (i = 0; i < UBX_num_alarms; ++i)
 	{
-		if ((current->hMSL <= UBX_alarms[i].elev + UBX_alarm_window_above) &&
-		    (current->hMSL >= UBX_alarms[i].elev - UBX_alarm_window_below))
+		const int32_t alarm_elev = UBX_alarms[i].elev + UBX_dz_elev;
+
+		if ((current->hMSL <= alarm_elev + UBX_alarm_window_above) &&
+		    (current->hMSL >= alarm_elev - UBX_alarm_window_below))
 		{
 			suppress_tone = 1;
 			break;
@@ -922,7 +924,8 @@ static void UBX_UpdateAlarms(
 	
 	for (i = 0; i < UBX_num_windows; ++i)
 	{
-		if ((UBX_windows[i].bottom <= current->hMSL) && (UBX_windows[i].top >= current->hMSL))
+		if ((UBX_windows[i].bottom + UBX_dz_elev <= current->hMSL) &&
+		    (UBX_windows[i].top + UBX_dz_elev >= current->hMSL))
 		{
 			suppress_tone = 1;
 			suppress_alt = 1;
@@ -968,7 +971,7 @@ static void UBX_UpdateAlarms(
 		
 		for (i = 0; i < UBX_num_alarms; ++i)
 		{
-			const int32_t alarm_elev = UBX_alarms[i].elev;
+			const int32_t alarm_elev = UBX_alarms[i].elev + UBX_dz_elev;
 
 			if (alarm_elev >= min && alarm_elev < max)
 			{


### PR DESCRIPTION
Previously, we were applying DZ_Elev to alarm values when the alarm was loaded. This meant that if DZ_Elev was specified differently in the root and selectable configuration files, unexpected results would occur. Now we apply DZ_elev to the alarm elevation just before it's used, so DZ_Elev is treated just like any other configuration variable.