### PR TITLE
Clear config lists on first item

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -40,6 +40,10 @@
 #define FALSE 0
 #define TRUE  (!FALSE)
 
+#define CONFIG_FIRST_ALARM  0x01
+#define CONFIG_FIRST_WINDOW 0x02
+#define CONFIG_FIRST_SPEECH 0x04
+
 static const char Config_default[] PROGMEM = "\
 ; Firmware version " FLYSIGHT_VERSION "\r\n\
 \r\n\
@@ -268,6 +272,8 @@ static FRESULT Config_ReadSingle(
 	char    *name;
 	char    *result;
 	int32_t val;
+	
+	uint8_t first = 0;
 
 	FRESULT res;
 
@@ -333,6 +339,12 @@ static FRESULT Config_ReadSingle(
 		
 		if (!strcmp_P(name, Config_Alarm_Elev) && UBX_num_alarms < UBX_MAX_ALARMS)
 		{
+			if (!(first & CONFIG_FIRST_ALARM))
+			{
+				UBX_num_alarms = 0;
+				first |= CONFIG_FIRST_ALARM;
+			}
+			
 			++UBX_num_alarms;
 			UBX_alarms[UBX_num_alarms - 1].elev = val * 1000;
 			UBX_alarms[UBX_num_alarms - 1].type = 0;
@@ -350,6 +362,12 @@ static FRESULT Config_ReadSingle(
 		
 		if (!strcmp_P(name, Config_Win_Top) && UBX_num_windows < UBX_MAX_WINDOWS)
 		{
+			if (!(first & CONFIG_FIRST_WINDOW))
+			{
+				UBX_num_windows = 0;
+				first |= CONFIG_FIRST_WINDOW;
+			}
+			
 			++UBX_num_windows;
 			UBX_windows[UBX_num_windows - 1].top = val * 1000;
 		}
@@ -360,6 +378,12 @@ static FRESULT Config_ReadSingle(
 
 		if (!strcmp_P(name, Config_Sp_Mode) && UBX_num_speech < UBX_MAX_SPEECH)
 		{
+			if (!(first & CONFIG_FIRST_SPEECH))
+			{
+				UBX_num_speech = 0;
+				first |= CONFIG_FIRST_SPEECH;
+			}
+			
 			++UBX_num_speech;
 			UBX_speech[UBX_num_speech - 1].mode = val;
 			UBX_speech[UBX_num_speech - 1].units = UBX_UNITS_MPH;


### PR DESCRIPTION
There are two kinds of entry in a configuration file:

1. Entries which are only included once, e.g., "Model". If these are repeated, then the value is simply overwritten.
2. Entries which can be repeated, e.g., "Alarm_Elev", "Win_Top" and "Sp_Mode". These items represent a list, and when the item is repeated, a new entry is added to the list.

With selectable configuration files, two different configuration files can be loaded at once. The FlySight will treat these as though the two files had been concatenated--first the "config.txt" in the root folder and then the selected configuration file. This has different implications for the two kinds of entry:

1. For entries which are only included once, a default value can be created in the root "config.txt". If the same value is defined in the selected configuration file, then it is overwritten with the value found in that file.
2. For entries which can be repeated, entries in the root "config.txt" are added first, then entries in the selected configuration file are added to the end of that list. However, this can result in a lot of confusion. For example, if there is an alarm in the root "config.txt" file, even if "Alarm_Type" is set to "No alarm", it will take up one alarm slot. As a result, if the user has also defined 10 alarms in the selected configuration, the last one will not be loaded.

To fix this, we are now treating entire lists logically as though they were a single item. For example, a default alarm list can be defined in the root "config.txt" file. If a second list of alarms is included in the selected configuration file, then the original list is cleared and the second list takes its place. If no second list is defined, then the list defined in the root "config.txt" file stays.

We believe this is a more consistent treatment and will lead to fewer "surprises" for users.