### PR TITLE
Fix issue with tones on startup

### DIFF
--- a/src/Tone.c
+++ b/src/Tone.c
@@ -174,7 +174,7 @@ void Tone_Update(void)
 {
 	static uint16_t tone_timer = 0;
 
-	if (!Tone_hold && 0 - tone_timer <= Tone_rate)
+	if (!Tone_hold && Tone_rate > 0 && 0 - tone_timer <= Tone_rate)
 	{
 		Tone_flags |= TONE_FLAGS_BEEP;
 	}


### PR DESCRIPTION
Fix an issue which occurred when Tone_rate was zero and tone_timer was also zero.