### PR TITLE
lie about how much power we're going to use

### DIFF
--- a/src/Descriptors.c
+++ b/src/Descriptors.c
@@ -88,7 +88,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 
 			.ConfigAttributes       = USB_CONFIG_ATTR_RESERVED,
 
-			.MaxPowerConsumption    = USB_CONFIG_POWER_MA(250)
+			.MaxPowerConsumption    = USB_CONFIG_POWER_MA(50)
 		},
 
 #ifdef USE_SERIAL_INTERFACE
@@ -192,7 +192,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			.EndpointSize           = CDC_TXRX_EPSIZE,
 			.PollingIntervalMS      = 0x05
 		},
-#endif		
+#endif
 
 	.MS_Interface =
 		{


### PR DESCRIPTION
We talked about this a while ago, I spent a while trying to figure out how to make this runtime configurable, but it looks like that's basically a hard constraint- it turns out if you put stuff into ROM you can't change it later.

My recollection was that this number is already something of a fiction, so are you ok with making it a lot lower? This makes the device work a lot better with mobile devices, especially phones.